### PR TITLE
Adjusted `react` and `react-dom` dependencies

### DIFF
--- a/react-app/package.json
+++ b/react-app/package.json
@@ -29,8 +29,6 @@
     "d3": "^7.2.0",
     "d3-color": "^3.0.1",
     "d3-interpolate": "^3.0.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "web-vitals": "^3.0.0"
   },
   "repository": {
@@ -71,10 +69,16 @@
     "@types/styled-components": "^5.1.25",
     "babel-loader": "^8.1.0",
     "html-webpack-plugin": "^5.5.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-scripts": "^5.0.1",
     "semantic-release": "^19.0.2",
     "styled-components": "^5.3.5",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.4"
+  },
+  "peerDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   }
 }


### PR DESCRIPTION
For a package that is supposed to be used in other packages, it is not recommended to have `react` or `react-dom` as `dependencies`. This might lead to having two different `react` versions installed which causes conflicts. The best practice is to add `react` to the `peerDependencies` in order to just specifiy which version this package requires/supports but not to install anything. As for `npm < 7`, both packages can be added to `devDependencies` in order to have them getting installed when developing the package. However, `npm >= 7` does automatically install `peerDependencies` (https://blog.npmjs.org/post/617484925547986944/npm-v7-series-introduction). 

For more information, see:
- https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react
- https://stackoverflow.com/questions/30451556/what-is-the-correct-way-of-adding-a-dependency-to-react-in-your-package-json-for
- https://stackoverflow.com/questions/61696213/best-practices-for-using-peerdependencyand-devdependency