### PR TITLE
Fix: fixed the selector disappearance on domain pop-up click

### DIFF
--- a/react-app/src/component/Legend/ColorLegend.tsx
+++ b/react-app/src/component/Legend/ColorLegend.tsx
@@ -176,11 +176,14 @@ export const ColorLegend: React.FC<ColorLegendProps> = ({
     [getColorName]
   );
 
-  const handleModalClick = React.useCallback((e: Event) => {
-    if (!colorSelectorRef.current?.contains(e.target as Node) && isOpen) {
-      setIsOpen(false);
-    }
-  }, [isOpen])
+  const handleModalClick = React.useCallback(
+    (e: Event) => {
+      if (!colorSelectorRef.current?.contains(e.target as Node) && isOpen) {
+        setIsOpen(false);
+      }
+    },
+    [isOpen]
+  );
 
   React.useEffect(() => {
     if (isOpen && isModal) {

--- a/react-app/src/component/Legend/ColorLegend.tsx
+++ b/react-app/src/component/Legend/ColorLegend.tsx
@@ -176,11 +176,11 @@ export const ColorLegend: React.FC<ColorLegendProps> = ({
     [getColorName]
   );
 
-  function handleModalClick(e: Event) {
-    if (!colorSelectorRef.current?.contains(e.target as Node)) {
+  const handleModalClick = React.useCallback((e: Event) => {
+    if (!colorSelectorRef.current?.contains(e.target as Node) && isOpen) {
       setIsOpen(false);
     }
-  }
+  }, [isOpen])
 
   React.useEffect(() => {
     if (isOpen && isModal) {
@@ -189,7 +189,7 @@ export const ColorLegend: React.FC<ColorLegendProps> = ({
       document.removeEventListener("mousedown", handleModalClick);
     }
     return () => document.removeEventListener("mousedown", handleModalClick);
-  }, [isOpen, isModal]);
+  }, [isOpen, isModal, handleModalClick]);
 
   /* Defining some states to rerender the component upon prop change in storybook */
 


### PR DESCRIPTION
Upon first render, the modal prop worked as expected when the pop-up domain option is edited\clicked.

However, if the color legend is re-rendered (due to changing the color scale type or anything else), the color selector disappears when the pop-up domain window is clicked.

This has been fixed.