### PR TITLE
fix: removed the height and width css styles on the parent div

### DIFF
--- a/react-app/src/component/Legend/ColorLegend.tsx
+++ b/react-app/src/component/Legend/ColorLegend.tsx
@@ -218,7 +218,7 @@ export const ColorLegend: React.FC<ColorLegendProps> = ({
   }, [legendScaleSize]);
 
   return (
-    <div style={{ position: "relative", height: "92vh", width: "97vw" }}>
+    <div style={{ position: "relative" }}>
       <div
         ref={divRef}
         onClick={toggleColorSelector}


### PR DESCRIPTION
This issue was raised when creating multiple color legends in the deckgl webviz component