### PR TITLE
build: disabled jekyll in gh-pages.

### DIFF
--- a/.github/workflows/conventional_commit.yml
+++ b/.github/workflows/conventional_commit.yml
@@ -9,7 +9,7 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: webiny/action-conventional-commits@v1.0.3
+      - uses: webiny/action-conventional-commits@v1.1.0
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Install dependencies
         run: npm --prefix=react-app ci
@@ -38,6 +38,8 @@ jobs:
           git rm -r --ignore-unmatch *
 
           mv ../storybook-static .
+
+          touch .nojekyll
 
           git add .
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Should hopefully fix storybook in gh-pages (jekyll doesn't allow file names starting with underscore).

Also bumped workflow action versions.