### PR TITLE
fix: possible crash in rgbValues

### DIFF
--- a/react-app/src/component/Utils/legendCommonFunction.ts
+++ b/react-app/src/component/Utils/legendCommonFunction.ts
@@ -242,7 +242,7 @@ export function rgbValues(
     point = log(point);
   }
 
-  // check if the user has there own colortables else use default one
+  // check if the user has his own colortables else use default one
   const getColorTables = iscolorTablesDefined
     ? iscolorTablesDefined
     : colorTables;

--- a/react-app/src/component/Utils/legendCommonFunction.ts
+++ b/react-app/src/component/Utils/legendCommonFunction.ts
@@ -191,7 +191,7 @@ export function getRgbData(
         const firstColorArray = colorTableColors[index - 1];
         const secondColorArray = colorTableColors[index];
 
-        if ((firstColorArray || secondColorArray) !== undefined) {
+        if (firstColorArray && secondColorArray) {
           const t0 = firstColorArray[0];
           const t1 = secondColorArray[0];
           const t = (point - t0) / (t1 - t0); // t = 0.0 gives first color, t = 1.0 gives second color.
@@ -242,7 +242,7 @@ export function rgbValues(
     point = log(point);
   }
 
-  // check if the user has there own colortables else use defualt one
+  // check if the user has there own colortables else use default one
   const getColorTables = iscolorTablesDefined
     ? iscolorTablesDefined
     : colorTables;
@@ -307,7 +307,7 @@ export function rgbValues(
       const firstColorArray = colorTableColors[index - 1];
       const secondColorArray = colorTableColors[index];
 
-      if ((firstColorArray || secondColorArray) !== undefined) {
+      if (firstColorArray && secondColorArray) {
         const t0 = firstColorArray[0];
         const t1 = secondColorArray[0];
         const t = (point - t0) / (t1 - t0); // t = 0.0 gives first color, t = 1.0 gives second color.


### PR DESCRIPTION
Experienced when calling this function in a tooltip readout while displaying a new object.